### PR TITLE
Change Jenkins Blue Ocean image version

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ docker run --name jenkins-blueocean --restart=on-failure --detach \
   --publish 8080:8080 --publish 50000:50000 \
   --volume jenkins-data:/var/jenkins_home \
   --volume jenkins-docker-certs:/certs/client:ro \
-  myjenkins-blueocean:2.414.2
+  docker.io/devopsjourney1/jenkins-blueocean:2.332.3-1 ##For the users who pulled the pre-built image directly
 ```
 
 ### Windows


### PR DESCRIPTION
For users who pulled the pre-built image directly, the full regeistery name needs to be provided, otherwise will users will have access denied